### PR TITLE
add default exports for sketch sub modules

### DIFF
--- a/async.d.ts
+++ b/async.d.ts
@@ -1,0 +1,4 @@
+import { Async } from "./";
+
+declare const sketchAsync: Async;
+export default sketchAsync;

--- a/data-supplier.d.ts
+++ b/data-supplier.d.ts
@@ -1,0 +1,4 @@
+import { DataSupplier } from "./";
+
+declare const sketchDataSupplier: DataSupplier;
+export default sketchDataSupplier;

--- a/dom.d.ts
+++ b/dom.d.ts
@@ -1,0 +1,4 @@
+import { SketchDom } from "./";
+
+declare const sketchDom: SketchDom;
+export default sketchDom;

--- a/settings.d.ts
+++ b/settings.d.ts
@@ -1,0 +1,4 @@
+import { Settings } from "./";
+
+declare const sketchSettings: Settings;
+export default sketchSettings;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,6 @@
     "compilerOptions": {
         "lib": [
             "es6"
-        ]
-    }
+        ],
+    },
 }

--- a/ui.d.ts
+++ b/ui.d.ts
@@ -1,0 +1,4 @@
+import { UI } from "./";
+
+declare const sketchUI: UI;
+export default sketchUI;


### PR DESCRIPTION
not sure if that's the best way of adding sub-modules, i tried adding `declare module` definitions to the index.d.ts file, but without success.

https://github.com/qjebbs/sketch.d.ts/issues/3